### PR TITLE
show "copied" feedback in messagebar instead of messagebox

### DIFF
--- a/QCopycanvas.py
+++ b/QCopycanvas.py
@@ -22,8 +22,10 @@
  ***************************************************************************/
 """
 from PyQt5.QtCore import (QSettings, QTranslator, qVersion, QCoreApplication, Qt)
-from PyQt5.QtGui import (QIcon, QImage, QFont, QKeySequence)
-from PyQt5.QtWidgets import (QAction, QApplication, QMessageBox, QWidget)
+from PyQt5.QtGui import (QIcon, QImage, QKeySequence)
+from PyQt5.QtWidgets import (QAction, QApplication, QWidget)
+from qgis.gui import QgsMessageBar
+from qgis.core import Qgis
 
 # Initialize Qt resources from file resources.py
 from .resources import *
@@ -185,20 +187,6 @@ class QCopycanvas:
                 action)
             self.iface.removeToolBarIcon(action)
 
-    def showMessage(self, title, msg, button):
-        msgBox = QMessageBox()
-        msgBox.setIcon(QMessageBox.Information)
-        msgBox.setWindowTitle(title)
-        msgBox.setText(msg)
-        msgBox.setStandardButtons(QMessageBox.Ok)
-        font = QFont()
-        font.setPointSize(9)
-        msgBox.setFont(font)
-        msgBox.setWindowFlags(Qt.CustomizeWindowHint | Qt.WindowStaysOnTopHint | Qt.WindowCloseButtonHint)
-        buttonY = msgBox.button(QMessageBox.Ok)
-        buttonY.setText(button)
-        buttonY.setFont(font)
-        msgBox.exec_()
 
     def run(self):
         """Run method that performs all the real work"""
@@ -206,4 +194,9 @@ class QCopycanvas:
         # Create the dialog with elements (after translation) and keep reference
         # Only create GUI ONCE in callback, so that it will only load when the plugin is started
         QApplication.clipboard().setImage(QImage(QWidget.grab(self.iface.mapCanvas())))
-        self.showMessage(title='QCopycanvas', msg='Copied map canvas successfully.', button='OK')
+        self.iface.messageBar().pushMessage(
+            "QCopycanvas",
+            self.tr("Copied map canvas successfully."),
+            level=Qgis.Info,
+            duration=2
+        )


### PR DESCRIPTION
This commit changes the code to show the user feedback in a messagebar (on top of the map, disappearing automatically) instead of in a messagebox (dialog you need to click away). 

Only while doing the PR I noticed a super similar PR from 4 days ago!! :dagger: 
Only difference I can find is me setting the duration to 2 seconds.

Well, go ahead and pick one of these and delete the other. Thanks!